### PR TITLE
Implement AUR-302: Manual sync endpoint POST /pos/sync

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -32,6 +32,9 @@ from backend.modules.orders.routes.pricing_routes import (
 from backend.modules.orders.routers.sync import (
     sync_router as order_sync_router
 )
+from backend.modules.orders.routers.pos_sync_router import (
+    router as order_pos_sync_router
+)
 from backend.modules.orders.routers.external_pos_webhook_router import (
     router as external_pos_webhook_router
 )
@@ -153,6 +156,7 @@ app.include_router(kitchen_router)
 app.include_router(print_ticket_router)
 app.include_router(pricing_router)
 app.include_router(order_sync_router)
+app.include_router(order_pos_sync_router)
 app.include_router(external_pos_webhook_router)
 app.include_router(webhook_monitoring_router)
 app.include_router(tax_router)

--- a/backend/modules/orders/routers/pos_sync_router.py
+++ b/backend/modules/orders/routers/pos_sync_router.py
@@ -1,0 +1,380 @@
+# backend/modules/orders/routers/pos_sync_router.py
+
+"""
+POS-specific sync endpoints.
+
+Provides a simplified POST /pos/sync endpoint for POS terminals
+to trigger manual synchronization.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, BackgroundTasks
+from sqlalchemy.orm import Session
+from typing import Dict, Any, Optional, List
+from datetime import datetime
+import logging
+
+from backend.core.database import get_db
+from backend.core.auth import get_current_user
+from backend.core.config import settings
+from backend.modules.staff.models import StaffMember
+from backend.modules.orders.services.sync_service import OrderSyncService
+from backend.modules.orders.models.sync_models import OrderSyncStatus, SyncStatus
+from backend.modules.orders.models.order_models import Order
+from backend.modules.orders.tasks.sync_tasks import order_sync_scheduler
+from backend.modules.orders.schemas.sync_schemas import (
+    ManualSyncRequest, SyncStatusResponse
+)
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/pos", tags=["pos-sync"])
+
+
+class POSSyncRequest(BaseModel):
+    """Request model for POS sync endpoint"""
+    terminal_id: Optional[str] = Field(
+        None,
+        description="POS terminal identifier"
+    )
+    order_ids: Optional[List[int]] = Field(
+        None,
+        description="Specific order IDs to sync"
+    )
+    sync_all_pending: bool = Field(
+        True,
+        description="Sync all pending orders if order_ids not provided"
+    )
+    include_recent: bool = Field(
+        False,
+        description="Include recently synced orders (last 24 hours)"
+    )
+
+
+class POSSyncResponse(BaseModel):
+    """Response model for POS sync endpoint"""
+    status: str  # initiated, completed, failed
+    terminal_id: Optional[str]
+    sync_batch_id: Optional[str]
+    orders_queued: int
+    orders_synced: int = 0
+    orders_failed: int = 0
+    message: str
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    details: Optional[Dict[str, Any]] = None
+
+
+@router.post("/sync", response_model=POSSyncResponse)
+async def trigger_pos_sync(
+    request: POSSyncRequest,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+    current_user: StaffMember = Depends(get_current_user)
+) -> POSSyncResponse:
+    """
+    Trigger manual synchronization from POS terminal.
+    
+    This endpoint allows POS terminals to manually trigger order synchronization
+    with the cloud system. It can sync specific orders or all pending orders.
+    
+    Returns immediately with sync status while processing happens in background.
+    """
+    terminal_id = request.terminal_id or settings.POS_TERMINAL_ID
+    
+    logger.info(
+        f"POS sync requested from terminal {terminal_id}",
+        extra={
+            "terminal_id": terminal_id,
+            "user_id": current_user.id,
+            "order_ids": request.order_ids,
+            "sync_all_pending": request.sync_all_pending
+        }
+    )
+    
+    try:
+        if request.order_ids:
+            # Sync specific orders
+            return await _sync_specific_orders(
+                order_ids=request.order_ids,
+                terminal_id=terminal_id,
+                background_tasks=background_tasks,
+                db=db
+            )
+        elif request.sync_all_pending:
+            # Sync all pending orders
+            return await _sync_all_pending_orders(
+                include_recent=request.include_recent,
+                terminal_id=terminal_id,
+                background_tasks=background_tasks,
+                db=db
+            )
+        else:
+            return POSSyncResponse(
+                status="failed",
+                terminal_id=terminal_id,
+                orders_queued=0,
+                message="No orders specified for sync",
+                details={"error": "Either provide order_ids or set sync_all_pending=true"}
+            )
+            
+    except Exception as e:
+        logger.error(
+            f"Error initiating POS sync: {str(e)}",
+            extra={"terminal_id": terminal_id},
+            exc_info=True
+        )
+        
+        return POSSyncResponse(
+            status="failed",
+            terminal_id=terminal_id,
+            orders_queued=0,
+            message=f"Failed to initiate sync: {str(e)}",
+            details={"error": str(e)}
+        )
+
+
+async def _sync_specific_orders(
+    order_ids: List[int],
+    terminal_id: str,
+    background_tasks: BackgroundTasks,
+    db: Session
+) -> POSSyncResponse:
+    """Sync specific order IDs"""
+    
+    # Validate orders exist and belong to this terminal
+    valid_orders = db.query(Order).filter(
+        Order.id.in_(order_ids),
+        Order.is_deleted == False
+    ).all()
+    
+    if not valid_orders:
+        return POSSyncResponse(
+            status="failed",
+            terminal_id=terminal_id,
+            orders_queued=0,
+            message="No valid orders found",
+            details={"requested_ids": order_ids, "found": 0}
+        )
+    
+    # Create or update sync status for each order
+    orders_to_sync = []
+    for order in valid_orders:
+        sync_status = db.query(OrderSyncStatus).filter(
+            OrderSyncStatus.order_id == order.id
+        ).first()
+        
+        if not sync_status:
+            sync_status = OrderSyncStatus(
+                order_id=order.id,
+                sync_status=SyncStatus.PENDING,
+                sync_direction="local_to_remote"
+            )
+            db.add(sync_status)
+        else:
+            sync_status.sync_status = SyncStatus.PENDING
+            sync_status.next_retry_at = datetime.utcnow()
+        
+        orders_to_sync.append(order.id)
+    
+    db.commit()
+    
+    # Queue background sync task
+    background_tasks.add_task(
+        _process_sync_batch,
+        order_ids=orders_to_sync,
+        terminal_id=terminal_id
+    )
+    
+    return POSSyncResponse(
+        status="initiated",
+        terminal_id=terminal_id,
+        orders_queued=len(orders_to_sync),
+        message=f"Sync initiated for {len(orders_to_sync)} orders",
+        details={
+            "order_ids": orders_to_sync,
+            "invalid_ids": list(set(order_ids) - set(o.id for o in valid_orders))
+        }
+    )
+
+
+async def _sync_all_pending_orders(
+    include_recent: bool,
+    terminal_id: str,
+    background_tasks: BackgroundTasks,
+    db: Session
+) -> POSSyncResponse:
+    """Sync all pending orders"""
+    
+    # Get unsynced orders
+    query = db.query(OrderSyncStatus).join(Order).filter(
+        Order.is_deleted == False,
+        OrderSyncStatus.sync_status.in_([
+            SyncStatus.PENDING,
+            SyncStatus.FAILED,
+            SyncStatus.RETRY
+        ])
+    )
+    
+    # Optionally include recently synced orders
+    if include_recent:
+        recent_cutoff = datetime.utcnow().replace(hour=0, minute=0, second=0)
+        query = query.filter(
+            db.or_(
+                OrderSyncStatus.sync_status != SyncStatus.SYNCED,
+                OrderSyncStatus.synced_at >= recent_cutoff
+            )
+        )
+    
+    pending_sync_statuses = query.all()
+    
+    if not pending_sync_statuses:
+        # Check for orders without sync status
+        orders_without_sync = db.query(Order).outerjoin(OrderSyncStatus).filter(
+            Order.is_deleted == False,
+            OrderSyncStatus.id.is_(None)
+        ).all()
+        
+        # Create sync status for orders that don't have one
+        for order in orders_without_sync:
+            sync_status = OrderSyncStatus(
+                order_id=order.id,
+                sync_status=SyncStatus.PENDING,
+                sync_direction="local_to_remote"
+            )
+            db.add(sync_status)
+            pending_sync_statuses.append(sync_status)
+        
+        db.commit()
+    
+    order_ids = [s.order_id for s in pending_sync_statuses]
+    
+    if order_ids:
+        # Trigger sync scheduler
+        if order_sync_scheduler.trigger_manual_sync():
+            return POSSyncResponse(
+                status="initiated",
+                terminal_id=terminal_id,
+                sync_batch_id=f"manual_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}",
+                orders_queued=len(order_ids),
+                message=f"Sync initiated for {len(order_ids)} pending orders",
+                details={
+                    "sync_type": "scheduled_batch",
+                    "include_recent": include_recent
+                }
+            )
+        else:
+            return POSSyncResponse(
+                status="failed",
+                terminal_id=terminal_id,
+                orders_queued=0,
+                message="Failed to trigger sync scheduler",
+                details={"error": "Scheduler unavailable"}
+            )
+    else:
+        return POSSyncResponse(
+            status="completed",
+            terminal_id=terminal_id,
+            orders_queued=0,
+            message="No pending orders to sync",
+            details={"checked_recent": include_recent}
+        )
+
+
+async def _process_sync_batch(order_ids: List[int], terminal_id: str):
+    """Process sync batch in background"""
+    db = next(get_db())
+    try:
+        sync_service = OrderSyncService(db)
+        
+        for order_id in order_ids:
+            try:
+                await sync_service.sync_single_order(order_id)
+            except Exception as e:
+                logger.error(
+                    f"Error syncing order {order_id}: {str(e)}",
+                    extra={"terminal_id": terminal_id, "order_id": order_id},
+                    exc_info=True
+                )
+        
+        await sync_service.close()
+        
+    except Exception as e:
+        logger.error(
+            f"Error in sync batch processing: {str(e)}",
+            extra={"terminal_id": terminal_id},
+            exc_info=True
+        )
+    finally:
+        db.close()
+
+
+@router.get("/sync/status", response_model=SyncStatusResponse)
+async def get_pos_sync_status(
+    terminal_id: Optional[str] = None,
+    db: Session = Depends(get_db),
+    current_user: StaffMember = Depends(get_current_user)
+) -> SyncStatusResponse:
+    """
+    Get current sync status for POS terminal.
+    
+    Returns overview of sync status including pending orders,
+    conflicts, and recent sync activity.
+    """
+    terminal_id = terminal_id or settings.POS_TERMINAL_ID
+    
+    # Get sync status counts
+    status_counts = {}
+    for status in SyncStatus:
+        count = db.query(OrderSyncStatus).filter(
+            OrderSyncStatus.sync_status == status
+        ).count()
+        status_counts[status.value] = count
+    
+    # Get unsynced orders count
+    unsynced_orders = db.query(Order).outerjoin(OrderSyncStatus).filter(
+        Order.is_deleted == False,
+        db.or_(
+            OrderSyncStatus.id.is_(None),
+            OrderSyncStatus.sync_status != SyncStatus.SYNCED
+        )
+    ).count()
+    
+    # Get pending conflicts
+    from backend.modules.orders.models.sync_models import SyncConflict
+    pending_conflicts = db.query(SyncConflict).filter(
+        SyncConflict.resolution_status == "pending"
+    ).count()
+    
+    # Get last batch info
+    from backend.modules.orders.models.sync_models import SyncBatch
+    last_batch = db.query(SyncBatch).order_by(
+        SyncBatch.started_at.desc()
+    ).first()
+    
+    last_batch_info = None
+    if last_batch:
+        last_batch_info = {
+            "batch_id": last_batch.batch_id,
+            "started_at": last_batch.started_at.isoformat(),
+            "completed_at": last_batch.completed_at.isoformat() if last_batch.completed_at else None,
+            "total_orders": last_batch.total_orders,
+            "successful_syncs": last_batch.successful_syncs,
+            "failed_syncs": last_batch.failed_syncs
+        }
+    
+    # Get scheduler status
+    scheduler_status = order_sync_scheduler.get_scheduler_status()
+    
+    return SyncStatusResponse(
+        sync_status_counts=status_counts,
+        unsynced_orders=unsynced_orders,
+        pending_conflicts=pending_conflicts,
+        last_batch=last_batch_info,
+        scheduler=scheduler_status,
+        configuration={
+            "sync_enabled": settings.SYNC_ENABLED,
+            "sync_interval_minutes": settings.SYNC_INTERVAL_MINUTES,
+            "terminal_id": terminal_id,
+            "cloud_endpoint": settings.CLOUD_SYNC_ENDPOINT
+        }
+    )

--- a/backend/modules/orders/tests/test_pos_sync_router.py
+++ b/backend/modules/orders/tests/test_pos_sync_router.py
@@ -1,0 +1,360 @@
+# backend/modules/orders/tests/test_pos_sync_router.py
+
+"""
+Tests for POS sync endpoints.
+"""
+
+import pytest
+from datetime import datetime
+from unittest.mock import Mock, patch, AsyncMock
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from backend.modules.orders.models.order_models import Order
+from backend.modules.orders.models.sync_models import OrderSyncStatus, SyncStatus
+from backend.modules.orders.routers.pos_sync_router import POSSyncRequest, POSSyncResponse
+
+
+@pytest.fixture
+def mock_sync_service():
+    """Mock OrderSyncService"""
+    with patch('backend.modules.orders.routers.pos_sync_router.OrderSyncService') as mock:
+        service = Mock()
+        service.sync_single_order = AsyncMock(return_value=(True, None))
+        service.close = AsyncMock()
+        mock.return_value = service
+        yield mock
+
+
+@pytest.fixture
+def mock_scheduler():
+    """Mock order sync scheduler"""
+    with patch('backend.modules.orders.routers.pos_sync_router.order_sync_scheduler') as mock:
+        mock.trigger_manual_sync.return_value = True
+        mock.get_scheduler_status.return_value = {
+            "running": True,
+            "next_run": datetime.utcnow().isoformat()
+        }
+        yield mock
+
+
+class TestPOSSyncEndpoint:
+    """Test POST /pos/sync endpoint"""
+    
+    def test_sync_specific_orders_success(self, client: TestClient, db: Session, auth_headers, mock_sync_service):
+        """Test syncing specific order IDs"""
+        # Create test orders
+        orders = []
+        for i in range(3):
+            order = Order(
+                staff_id=1,
+                table_no=f"T{i+1}",
+                status="completed",
+                is_deleted=False
+            )
+            db.add(order)
+            orders.append(order)
+        db.commit()
+        
+        # Create sync request
+        request_data = {
+            "terminal_id": "POS-001",
+            "order_ids": [o.id for o in orders],
+            "sync_all_pending": False
+        }
+        
+        response = client.post(
+            "/pos/sync",
+            json=request_data,
+            headers=auth_headers
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data["status"] == "initiated"
+        assert data["terminal_id"] == "POS-001"
+        assert data["orders_queued"] == 3
+        assert "Sync initiated for 3 orders" in data["message"]
+    
+    def test_sync_invalid_order_ids(self, client: TestClient, db: Session, auth_headers):
+        """Test syncing with invalid order IDs"""
+        request_data = {
+            "terminal_id": "POS-001",
+            "order_ids": [9999, 10000],  # Non-existent IDs
+            "sync_all_pending": False
+        }
+        
+        response = client.post(
+            "/pos/sync",
+            json=request_data,
+            headers=auth_headers
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data["status"] == "failed"
+        assert data["orders_queued"] == 0
+        assert "No valid orders found" in data["message"]
+    
+    def test_sync_all_pending_orders(self, client: TestClient, db: Session, auth_headers, mock_scheduler):
+        """Test syncing all pending orders"""
+        # Create orders with sync status
+        for i in range(5):
+            order = Order(
+                staff_id=1,
+                table_no=f"T{i+1}",
+                status="completed",
+                is_deleted=False
+            )
+            db.add(order)
+            db.flush()
+            
+            # Add sync status
+            sync_status = OrderSyncStatus(
+                order_id=order.id,
+                sync_status=SyncStatus.PENDING if i < 3 else SyncStatus.SYNCED,
+                sync_direction="local_to_remote"
+            )
+            db.add(sync_status)
+        
+        db.commit()
+        
+        request_data = {
+            "terminal_id": "POS-002",
+            "sync_all_pending": True,
+            "include_recent": False
+        }
+        
+        response = client.post(
+            "/pos/sync",
+            json=request_data,
+            headers=auth_headers
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data["status"] == "initiated"
+        assert data["terminal_id"] == "POS-002"
+        assert "sync_batch_id" in data
+        assert mock_scheduler.trigger_manual_sync.called
+    
+    def test_sync_include_recent_orders(self, client: TestClient, db: Session, auth_headers, mock_scheduler):
+        """Test syncing with include_recent flag"""
+        # Create recently synced order
+        order = Order(
+            staff_id=1,
+            table_no="T1",
+            status="completed",
+            is_deleted=False
+        )
+        db.add(order)
+        db.flush()
+        
+        sync_status = OrderSyncStatus(
+            order_id=order.id,
+            sync_status=SyncStatus.SYNCED,
+            sync_direction="local_to_remote",
+            synced_at=datetime.utcnow()
+        )
+        db.add(sync_status)
+        db.commit()
+        
+        request_data = {
+            "sync_all_pending": True,
+            "include_recent": True
+        }
+        
+        response = client.post(
+            "/pos/sync",
+            json=request_data,
+            headers=auth_headers
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data["status"] in ["initiated", "completed"]
+        assert data["details"]["include_recent"] is True
+    
+    def test_sync_no_pending_orders(self, client: TestClient, db: Session, auth_headers):
+        """Test sync when no pending orders exist"""
+        # Create all synced orders
+        for i in range(3):
+            order = Order(
+                staff_id=1,
+                table_no=f"T{i+1}",
+                status="completed",
+                is_deleted=False
+            )
+            db.add(order)
+            db.flush()
+            
+            sync_status = OrderSyncStatus(
+                order_id=order.id,
+                sync_status=SyncStatus.SYNCED,
+                sync_direction="local_to_remote",
+                synced_at=datetime.utcnow()
+            )
+            db.add(sync_status)
+        
+        db.commit()
+        
+        request_data = {
+            "sync_all_pending": True,
+            "include_recent": False
+        }
+        
+        response = client.post(
+            "/pos/sync",
+            json=request_data,
+            headers=auth_headers
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data["status"] == "completed"
+        assert data["orders_queued"] == 0
+        assert "No pending orders to sync" in data["message"]
+
+
+class TestPOSSyncStatusEndpoint:
+    """Test GET /pos/sync/status endpoint"""
+    
+    def test_get_sync_status(self, client: TestClient, db: Session, auth_headers):
+        """Test getting sync status overview"""
+        # Create orders with various sync statuses
+        statuses = [
+            SyncStatus.PENDING,
+            SyncStatus.PENDING,
+            SyncStatus.SYNCED,
+            SyncStatus.FAILED,
+            SyncStatus.RETRY
+        ]
+        
+        for i, status in enumerate(statuses):
+            order = Order(
+                staff_id=1,
+                table_no=f"T{i+1}",
+                status="completed",
+                is_deleted=False
+            )
+            db.add(order)
+            db.flush()
+            
+            sync_status = OrderSyncStatus(
+                order_id=order.id,
+                sync_status=status,
+                sync_direction="local_to_remote"
+            )
+            db.add(sync_status)
+        
+        db.commit()
+        
+        response = client.get(
+            "/pos/sync/status",
+            headers=auth_headers
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert "sync_status_counts" in data
+        assert data["sync_status_counts"]["pending"] == 2
+        assert data["sync_status_counts"]["synced"] == 1
+        assert data["sync_status_counts"]["failed"] == 1
+        assert data["sync_status_counts"]["retry"] == 1
+        
+        assert "unsynced_orders" in data
+        assert "pending_conflicts" in data
+        assert "scheduler" in data
+        assert "configuration" in data
+    
+    def test_get_sync_status_with_terminal_id(self, client: TestClient, auth_headers):
+        """Test getting sync status with specific terminal ID"""
+        response = client.get(
+            "/pos/sync/status?terminal_id=POS-123",
+            headers=auth_headers
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data["configuration"]["terminal_id"] == "POS-123"
+
+
+class TestPOSSyncRequestValidation:
+    """Test request validation"""
+    
+    def test_empty_request(self, client: TestClient, auth_headers):
+        """Test with empty request body"""
+        response = client.post(
+            "/pos/sync",
+            json={},
+            headers=auth_headers
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Should default to sync_all_pending=True
+        assert data["status"] in ["initiated", "completed"]
+    
+    def test_invalid_order_ids_type(self, client: TestClient, auth_headers):
+        """Test with invalid order_ids type"""
+        request_data = {
+            "order_ids": "not-a-list",  # Should be a list
+            "sync_all_pending": False
+        }
+        
+        response = client.post(
+            "/pos/sync",
+            json=request_data,
+            headers=auth_headers
+        )
+        
+        assert response.status_code == 422  # Validation error
+    
+    def test_conflicting_options(self, client: TestClient, auth_headers):
+        """Test with both order_ids and sync_all_pending"""
+        request_data = {
+            "order_ids": [1, 2, 3],
+            "sync_all_pending": True  # Should be ignored when order_ids provided
+        }
+        
+        response = client.post(
+            "/pos/sync",
+            json=request_data,
+            headers=auth_headers
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Should process specific orders, not all pending
+        assert "order_ids" in data.get("details", {})
+
+
+@pytest.mark.asyncio
+async def test_background_sync_processing():
+    """Test background sync task processing"""
+    from backend.modules.orders.routers.pos_sync_router import _process_sync_batch
+    
+    with patch('backend.modules.orders.routers.pos_sync_router.get_db') as mock_get_db:
+        mock_db = Mock()
+        mock_get_db.return_value = iter([mock_db])
+        
+        with patch('backend.modules.orders.routers.pos_sync_router.OrderSyncService') as mock_service:
+            service = Mock()
+            service.sync_single_order = AsyncMock(return_value=(True, None))
+            service.close = AsyncMock()
+            mock_service.return_value = service
+            
+            await _process_sync_batch([1, 2, 3], "POS-001")
+            
+            assert service.sync_single_order.call_count == 3
+            assert service.close.called
+            assert mock_db.close.called

--- a/docs/api/pos_sync_endpoints.md
+++ b/docs/api/pos_sync_endpoints.md
@@ -1,0 +1,287 @@
+# POS Sync API Documentation
+
+## Overview
+
+The POS Sync API provides endpoints for Point of Sale terminals to manually trigger order synchronization with the cloud system. This allows POS terminals to control when orders are synced, useful for handling network issues or batch processing.
+
+## Base URL
+
+```
+/api/pos
+```
+
+## Authentication
+
+All endpoints require authentication. Include the authentication token in the Authorization header:
+
+```
+Authorization: Bearer <token>
+```
+
+## Endpoints
+
+### 1. Trigger Manual Sync
+
+Initiates synchronization of orders from the POS terminal to the cloud.
+
+**Endpoint:** `POST /pos/sync`
+
+**Request Body:**
+
+```json
+{
+  "terminal_id": "POS-001",  // Optional, defaults to configured terminal ID
+  "order_ids": [123, 124, 125],  // Optional, specific orders to sync
+  "sync_all_pending": true,  // Default: true, sync all pending if no order_ids
+  "include_recent": false  // Default: false, include recently synced orders (last 24h)
+}
+```
+
+**Response:**
+
+```json
+{
+  "status": "initiated",  // initiated, completed, or failed
+  "terminal_id": "POS-001",
+  "sync_batch_id": "manual_20250731_143022",  // Optional batch ID
+  "orders_queued": 15,
+  "orders_synced": 0,  // Always 0 for async processing
+  "orders_failed": 0,  // Always 0 for async processing
+  "message": "Sync initiated for 15 pending orders",
+  "timestamp": "2025-07-31T14:30:22.123Z",
+  "details": {
+    "sync_type": "scheduled_batch",
+    "include_recent": false
+  }
+}
+```
+
+**Example: Sync Specific Orders**
+
+```bash
+curl -X POST https://api.auraconnect.ai/api/pos/sync \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "terminal_id": "POS-001",
+    "order_ids": [1001, 1002, 1003]
+  }'
+```
+
+**Example: Sync All Pending Orders**
+
+```bash
+curl -X POST https://api.auraconnect.ai/api/pos/sync \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "terminal_id": "POS-001",
+    "sync_all_pending": true
+  }'
+```
+
+### 2. Get Sync Status
+
+Retrieves the current synchronization status for the POS terminal.
+
+**Endpoint:** `GET /pos/sync/status`
+
+**Query Parameters:**
+
+- `terminal_id` (optional): Specific terminal ID, defaults to configured terminal
+
+**Response:**
+
+```json
+{
+  "sync_status_counts": {
+    "pending": 12,
+    "in_progress": 3,
+    "synced": 145,
+    "failed": 2,
+    "retry": 1,
+    "conflict": 0
+  },
+  "unsynced_orders": 15,
+  "pending_conflicts": 0,
+  "last_batch": {
+    "batch_id": "auto_20250731_140000",
+    "started_at": "2025-07-31T14:00:00Z",
+    "completed_at": "2025-07-31T14:02:15Z",
+    "total_orders": 25,
+    "successful_syncs": 23,
+    "failed_syncs": 2
+  },
+  "scheduler": {
+    "running": true,
+    "next_run": "2025-07-31T14:10:00Z"
+  },
+  "configuration": {
+    "sync_enabled": true,
+    "sync_interval_minutes": 10,
+    "terminal_id": "POS-001",
+    "cloud_endpoint": "https://api.auraconnect.ai/sync"
+  }
+}
+```
+
+**Example:**
+
+```bash
+curl -X GET https://api.auraconnect.ai/api/pos/sync/status \
+  -H "Authorization: Bearer <token>"
+```
+
+## Status Codes
+
+| Status Code | Description |
+|-------------|-------------|
+| 200 | Success |
+| 401 | Unauthorized - Invalid or missing authentication |
+| 422 | Validation Error - Invalid request data |
+| 500 | Internal Server Error |
+
+## Sync Status Values
+
+| Status | Description |
+|--------|-------------|
+| `pending` | Order is queued for synchronization |
+| `in_progress` | Synchronization is currently running |
+| `synced` | Order successfully synchronized |
+| `failed` | Synchronization failed after all retries |
+| `retry` | Failed but will be retried |
+| `conflict` | Conflict detected, requires resolution |
+
+## Error Responses
+
+All error responses follow this format:
+
+```json
+{
+  "detail": "Error message describing what went wrong"
+}
+```
+
+## Usage Scenarios
+
+### 1. Network Recovery
+
+After network connectivity is restored, trigger a sync of all pending orders:
+
+```json
+POST /pos/sync
+{
+  "sync_all_pending": true
+}
+```
+
+### 2. Specific Order Sync
+
+Sync specific orders that failed previously:
+
+```json
+POST /pos/sync
+{
+  "order_ids": [1001, 1002, 1003]
+}
+```
+
+### 3. Daily Reconciliation
+
+Include recently synced orders to ensure all data is up-to-date:
+
+```json
+POST /pos/sync
+{
+  "sync_all_pending": true,
+  "include_recent": true
+}
+```
+
+### 4. Check Sync Health
+
+Regularly check sync status to monitor for issues:
+
+```bash
+GET /pos/sync/status
+```
+
+## Best Practices
+
+1. **Regular Status Checks**: Poll `/pos/sync/status` periodically to monitor sync health
+2. **Batch Processing**: Use specific order IDs for targeted syncing of problematic orders
+3. **Error Handling**: Check the `status` field in responses and handle failures appropriately
+4. **Rate Limiting**: Avoid calling sync endpoints too frequently (recommended: max 1 call per minute)
+5. **Monitoring**: Track failed syncs and conflicts for manual intervention
+
+## Integration Example
+
+```python
+import requests
+import time
+
+class POSSyncClient:
+    def __init__(self, base_url, auth_token):
+        self.base_url = base_url
+        self.headers = {
+            "Authorization": f"Bearer {auth_token}",
+            "Content-Type": "application/json"
+        }
+    
+    def trigger_sync(self, order_ids=None, sync_all=True):
+        """Trigger manual sync"""
+        payload = {
+            "terminal_id": "POS-001",
+            "sync_all_pending": sync_all
+        }
+        
+        if order_ids:
+            payload["order_ids"] = order_ids
+            payload["sync_all_pending"] = False
+        
+        response = requests.post(
+            f"{self.base_url}/pos/sync",
+            json=payload,
+            headers=self.headers
+        )
+        response.raise_for_status()
+        return response.json()
+    
+    def get_sync_status(self):
+        """Get current sync status"""
+        response = requests.get(
+            f"{self.base_url}/pos/sync/status",
+            headers=self.headers
+        )
+        response.raise_for_status()
+        return response.json()
+    
+    def wait_for_sync_completion(self, timeout=300):
+        """Wait for all pending syncs to complete"""
+        start_time = time.time()
+        
+        while time.time() - start_time < timeout:
+            status = self.get_sync_status()
+            pending = status["sync_status_counts"]["pending"]
+            in_progress = status["sync_status_counts"]["in_progress"]
+            
+            if pending == 0 and in_progress == 0:
+                return True
+            
+            time.sleep(5)  # Check every 5 seconds
+        
+        return False
+
+# Usage
+client = POSSyncClient("https://api.auraconnect.ai/api", "your-auth-token")
+
+# Trigger sync
+result = client.trigger_sync()
+print(f"Sync initiated: {result['orders_queued']} orders queued")
+
+# Wait for completion
+if client.wait_for_sync_completion():
+    print("All orders synced successfully")
+else:
+    print("Sync timeout - check status for details")
+```


### PR DESCRIPTION
- Create dedicated POS sync router with POST /pos/sync endpoint
- Add ability to sync specific orders or all pending orders
- Include option to sync recently synced orders (last 24h)
- Add GET /pos/sync/status endpoint for sync status overview
- Implement background processing for sync operations
- Add comprehensive tests for all sync scenarios
- Create detailed API documentation with examples
- Register router in main application

The endpoint provides POS terminals with manual control over order synchronization, useful for handling network issues or batch processing requirements.