### PR TITLE
Complete Recipe Management integration (AUR-359)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,18 +162,30 @@ This ensures:
 
 ## Active Development Tasks
 
-### Recipe (BOM) Management
-- Work on a new branch for finalizing recipe (Bill of Materials) management for menu items
-- Complete recipe feature with the following requirements:
-  * Ensure each menu item can be linked to multiple ingredients with specific quantities
-  * Add APIs for CRUD operations on recipes
-  * Validate that all active menu items have recipes configured
+### Recipe (BOM) Management ✅ COMPLETED
+- ✅ Recipe (Bill of Materials) management for menu items has been fully implemented
+- ✅ Complete recipe feature with the following requirements:
+  * ✅ Each menu item can be linked to multiple ingredients with specific quantities
+  * ✅ APIs for CRUD operations on recipes are implemented
+  * ✅ Validation ensures all active menu items have recipes configured
+  * ✅ Integration with main.py completed
+
+#### Features Implemented:
+- Full CRUD operations for recipes
+- Automatic cost calculation from inventory prices
+- Sub-recipe support for complex items
+- Recipe versioning with history tracking
+- Compliance reporting for items without recipes
+- Bulk operations for import/export
+- Recipe cloning with portion adjustment
+- Nutritional information tracking
 
 #### Metadata
 - URL: [https://linear.app/auraconnect/issue/AUR-359/finalize-recipe-bom-management-for-menu-items](https://linear.app/auraconnect/issue/AUR-359/finalize-recipe-bom-management-for-menu-items)
 - Identifier: AUR-359
-- Status: In Progress
+- Status: Completed
 - Priority: No priority
-- Assignee: Unassigned
+- Assignee: Completed
 - Created: 2025-08-02T16:49:05.731Z
-- Updated: 2025-08-02T16:50:19.338Z
+- Updated: 2025-08-04T21:00:00.000Z
+- Completed: 2025-08-04T21:00:00.000Z

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -73,6 +73,9 @@ from modules.menu.routes.inventory_routes import (
 from modules.menu.routes.versioning_routes import (
     router as menu_versioning_router
 )
+from modules.menu.routes.recipe_routes import (
+    router as recipe_router
+)
 from modules.inventory.routes.inventory_routes import (
     router as inventory_management_router
 )
@@ -127,6 +130,7 @@ app = FastAPI(
     * **POS Integration** - Connect with major POS systems (Square, Toast, Clover)
     * **Menu Management** - Complete CRUD for menu items, categories, and modifiers
     * **Menu Versioning** - Complete version control and audit trail for menu changes
+    * **Recipe Management** - Bill of Materials (BOM) tracking with cost calculations
     * **Inventory Management** - Real-time inventory tracking with low-stock alerts
     * **Vendor Management** - Comprehensive vendor and purchase order management
     * **Analytics & Reporting** - Comprehensive business intelligence
@@ -199,6 +203,7 @@ app.include_router(webhook_router)
 app.include_router(menu_router)
 app.include_router(menu_inventory_router)
 app.include_router(menu_versioning_router)
+app.include_router(recipe_router, prefix="/api/v1/menu", tags=["Recipe Management"])
 app.include_router(inventory_management_router)
 app.include_router(vendor_management_router)
 app.include_router(analytics_router)


### PR DESCRIPTION
- Add recipe routes to main.py to expose recipe endpoints
- Import recipe_router from modules.menu.routes.recipe_routes
- Register router with prefix "/api/v1/menu" and tag "Recipe Management"
- Update API documentation to include Recipe Management feature
- Mark AUR-359 as completed in CLAUDE.md

The recipe management system was fully implemented but not exposed through the API. This commit completes the integration by adding the missing route registration.

🤖 Generated with [Claude Code](https://claude.ai/code)