### PR TITLE
Fix Mermaid diagram syntax error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ graph TB
     end
     
     subgraph "Data Layer"
-        E[(PostgreSQL<br/>Multi-tenant | Partitioned | Replicated)]
+        E[(PostgreSQL<br/>Multi-tenant - Partitioned - Replicated)]
     end
     
     A1 --> B


### PR DESCRIPTION
Replace pipe characters with hyphens in PostgreSQL node label to resolve Mermaid parse error. The pipe character is a special character in Mermaid and was causing the diagram to fail rendering.

Changed: 'Multi-tenant | Partitioned | Replicated'
To: 'Multi-tenant - Partitioned - Replicated'